### PR TITLE
Add aarch64[arm64] support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,32 @@ language: minimal
 services:
   - docker
 
+jobs:
+  include:
+    - stage: Build and Publist Docker images
+      arch: amd64
+      env: PLAT=amd64
+    - arch: arm64
+      env: PLAT=arm64
+    - stage: Creating multiarch manifest file
+      script:
+        - echo "Nothing to do during 'Script'"
+      deploy:
+        provider: script
+        script: bash .travis/create_push_multiarch_manifest.sh
+        on:
+          branch: master
+          tags: true
+
 before_install:
-  - docker build -t ferrarimarco/github-changelog-generator:latest .
+  - source .travis/utils.sh
+
 script:
-  - docker run --rm -it ferrarimarco/github-changelog-generator:latest
+  - build_docker_image
+
+deploy:
+  provider: script
+  script: bash .travis/upload_docker_img.sh
+  on:
+    branch: master
+    tags: true

--- a/.travis/create_push_multiarch_manifest.sh
+++ b/.travis/create_push_multiarch_manifest.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+. .travis/utils.sh
+
+VERSION=$( get_version )
+
+create_multiarch_manifest $VERSION "latest"
+docker_push
+
+create_multiarch_manifest $VERSION
+docker_push $VERSION

--- a/.travis/upload_docker_img.sh
+++ b/.travis/upload_docker_img.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+. .travis/utils.sh
+VERSION=$( get_version )
+docker_push $VERSION ${PLAT}

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Get the current release version
+get_version() {
+    version=$(cat Gemfile | grep github_changelog_generator | awk -F "'" '{print $4}')
+    echo "$version"
+}
+
+# Build and test docker images
+build_docker_image() {
+    version=$( get_version )
+    docker build -t ferrarimarco/github-changelog-generator:manifest-${PLAT}-${version} .
+    docker run --rm -i ferrarimarco/github-changelog-generator:manifest-${PLAT}-${version}
+}
+
+# Function usages: upload docker image/manifest
+# Syntax:
+# docker_push <version> <arch>
+# docker_push <version>
+# docker_push
+docker_push (){
+    version=$1
+    plat=$2
+    image=""
+    flag="manifest"
+
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+    if [ ! -z "${plat}" ] && [ ! -z "${version}" ]; then
+        image="ferrarimarco/github-changelog-generator:manifest-${plat}-${version}"
+        flag=""
+    elif [ ! -z "${version}" ]; then
+        image="ferrarimarco/github-changelog-generator:manifest-${version}"
+    else
+        image="ferrarimarco/github-changelog-generator:manifest-latest"
+    fi
+    echo "docker ${flag} push ${image}"
+    docker ${flag} push ${image}
+    docker logout
+}
+
+# Function usages: create multiarch manifest
+# Syntax:
+# create_multiarch_manifest <latest>
+# create_multiarch_manifest
+create_multiarch_manifest(){
+    # To enable manifest create feature
+    export DOCKER_CLI_EXPERIMENTAL=enabled
+    version="$1"
+    multiarch_manifest=${2:-$version}
+    docker manifest create \
+        ferrarimarco/github-changelog-generator:manifest-${multiarch_manifest} \
+        --amend ferrarimarco/github-changelog-generator:manifest-amd64-${version} \
+        --amend ferrarimarco/github-changelog-generator:manifest-arm64-${version}
+}


### PR DESCRIPTION
**Fix:** Add support to upload aarch64 docker image on docker hub. Closes https://github.com/github-changelog-generator/docker-github-changelog-generator/issues/33

You need to feed docker hub credentials into Travis builds as DOCKER_USERNAME and DOCKER_PASSWORD to upload the docker images on docker hub.


Signed-off-by: odidev odidev@puresoftware.com